### PR TITLE
Publish the correct ClientApp bundle directory

### DIFF
--- a/VueDotnetCoreTemplate.csproj
+++ b/VueDotnetCoreTemplate.csproj
@@ -41,7 +41,7 @@
 
     <!-- Include the newly-built files in the publish output -->
     <ItemGroup>
-      <DistFiles Include="$(SpaRoot)build\**" />
+      <DistFiles Include="$(SpaRoot)dist\**" />
       <ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
         <RelativePath>%(DistFiles.Identity)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>


### PR DESCRIPTION
The Vue CLI will by default output to ClientApp/dist, I believe the build path is just leftover remains from the React template used as base for this